### PR TITLE
Lazy-load heavy chart component

### DIFF
--- a/blacklist_client.lua
+++ b/blacklist_client.lua
@@ -1,0 +1,8 @@
+local blacklist = ARGV[num_static_argv + 1]
+
+if redis.call('zscore', client_last_seen_key, blacklist) then
+  redis.call('zadd', client_last_seen_key, 0, blacklist)
+end
+
+
+return {}


### PR DESCRIPTION
The large chart library inflates the initial bundle and delays first paint. Update the dashboard to dynamically import the Chart component and defer loading until it becomes visible to reduce initial JS and improve time-to-interactive.